### PR TITLE
Enable SavedStateHandle for VM Construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Convenient extensions built on top of the Android ViewModel Extensions library t
 
 ## :hammer_and_wrench:  Usage
 
-These extensions create an Android `ViewModel` scoped to an Activity. 
+These extensions create an Android ViewModel scoped to an Activity. 
 
 When in an Activity (`ComponentActivity`):
 
 ```kotlin
-private val viewModel: MyViewModel by viewModelBuilder {
+private val viewModel: MyViewModel by lazyViewModels {
     MyViewModel(repo = MyRepository())  
 }
 ```
@@ -19,8 +19,43 @@ private val viewModel: MyViewModel by viewModelBuilder {
 When in a Fragment, create an Activity-scoped ViewModel with:
 
 ```kotlin
-private val viewModel: MyViewModel by activityViewModelBuilder {
+private val viewModel: MyViewModel by lazyActivityViewModels {
     MyViewModel(repo = MyRepository())  
+}
+```
+
+To create a ViewModel that utilizes `SavedStateHandle` via the constructor, use the Saved State versions of these extensions.
+
+When in an Activity (`ComponentActivity`):
+
+```kotlin
+private val viewModel: MyViewModel by lazySavedStateViewModels { handle: SavedStateHandle ->
+    MyViewModel(
+        repo = MyRepository(),
+        savedStateHandle = handle
+    )
+}
+```
+
+When in a Fragment, create an Activity-scoped View Model with: 
+
+```kotlin
+private val viewModel: MyViewModel by lazySavedStateActivityViewModels { handle: SavedStateHandle ->
+    MyViewModel(
+        repo = MyRepository(),
+        savedStateHandle = handle
+    )
+}
+```
+
+Additionally, if you prefer to customize the `SavedStateRegistryOwner` that provides your `SavedStateHandle`, you can pass one in:
+
+```kotlin
+private val viewModel: MyViewModel by lazySavedStateActivityViewModels(this.requireActivity()) { handle: SavedStateHandle ->
+    MyViewModel(
+        repo = MyRepository(),
+        savedStateHandle = handle
+    )
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ private val viewModel: MyViewModel by lazyActivityViewModels {
 }
 ```
 
-# SavedStateHandle
+### SavedStateHandle
 
 To create a ViewModel that utilizes [`SavedStateHandle`](https://developer.android.com/reference/androidx/lifecycle/SavedStateHandle) via the constructor, use the Saved State versions of these extensions.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Convenient extensions built on top of the Android ViewModel Extensions library t
 
 These extensions create an Android ViewModel scoped to an Activity. 
 
+### Basic Usage
+
 When in an Activity (`ComponentActivity`):
 
 ```kotlin
@@ -24,7 +26,9 @@ private val viewModel: MyViewModel by lazyActivityViewModels {
 }
 ```
 
-To create a ViewModel that utilizes `SavedStateHandle` via the constructor, use the Saved State versions of these extensions.
+# SavedStateHandle
+
+To create a ViewModel that utilizes [`SavedStateHandle`](https://developer.android.com/reference/androidx/lifecycle/SavedStateHandle) via the constructor, use the Saved State versions of these extensions.
 
 When in an Activity (`ComponentActivity`):
 
@@ -48,7 +52,7 @@ private val viewModel: MyViewModel by lazySavedStateActivityViewModels { handle:
 }
 ```
 
-Additionally, if you prefer to customize the `SavedStateRegistryOwner` that provides your `SavedStateHandle`, you can pass one in:
+Additionally, if you prefer to customize the [`SavedStateRegistryOwner`](https://developer.android.com/reference/androidx/savedstate/SavedStateRegistryOwner) that provides your `SavedStateHandle`, you can pass one in:
 
 ```kotlin
 private val viewModel: MyViewModel by lazySavedStateActivityViewModels(this.requireActivity()) { handle: SavedStateHandle ->

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.2.1'
-    
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0"
+
     // Test pull of library from GitHub Packages
     //implementation 'dev.ajkueterman:lazyviewmodels:0.0.3'
 

--- a/app/src/main/java/dev/ajkueterman/testharness/MainActivity.kt
+++ b/app/src/main/java/dev/ajkueterman/testharness/MainActivity.kt
@@ -1,12 +1,17 @@
 package dev.ajkueterman.testharness
 
 import androidx.appcompat.app.AppCompatActivity
-import dev.ajkueterman.lazyviewmodels.viewModelBuilder
+import dev.ajkueterman.lazyviewmodels.lazySavedStateViewModels
+import dev.ajkueterman.lazyviewmodels.lazyViewModels
 
 class MainActivity: AppCompatActivity() {
 
-    private val viewModel: MainViewModel by viewModelBuilder {
+    private val viewModel: MainViewModel by lazyViewModels {
         MainViewModel("dep")
+    }
+
+    private val savedStateViewModel: SavedStateViewModel by lazySavedStateViewModels { savedStateHandle ->
+        SavedStateViewModel(savedStateHandle = savedStateHandle)
     }
 
 }

--- a/app/src/main/java/dev/ajkueterman/testharness/MainFragment.kt
+++ b/app/src/main/java/dev/ajkueterman/testharness/MainFragment.kt
@@ -1,12 +1,17 @@
 package dev.ajkueterman.testharness
 
 import androidx.fragment.app.Fragment
-import dev.ajkueterman.lazyviewmodels.activityViewModelBuilder
+import dev.ajkueterman.lazyviewmodels.lazyActivityViewModels
+import dev.ajkueterman.lazyviewmodels.lazySavedStateActivityViewModels
 
 class MainFragment: Fragment() {
 
-    private val viewModel: MainViewModel by activityViewModelBuilder {
-        MainViewModel("de")
+    private val viewModel: MainViewModel by lazyActivityViewModels {
+        MainViewModel("dep")
+    }
+
+    private val savedStateViewModel: SavedStateViewModel by lazySavedStateActivityViewModels { savedStateHandle ->
+        SavedStateViewModel(savedStateHandle = savedStateHandle)
     }
 
 }

--- a/app/src/main/java/dev/ajkueterman/testharness/SavedStateViewModel.kt
+++ b/app/src/main/java/dev/ajkueterman/testharness/SavedStateViewModel.kt
@@ -1,0 +1,6 @@
+package dev.ajkueterman.testharness
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+
+class SavedStateViewModel(private val savedStateHandle: SavedStateHandle): ViewModel()

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,3 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-
-# Build / Publishing Info
-group=dev.ajkueterman
-version=0.0.4

--- a/lazyviewmodels/build.gradle
+++ b/lazyviewmodels/build.gradle
@@ -12,7 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 30
-        versionName "0.0.4"
+        versionName "0.1.0"
+        archivesBaseName = "${archivesBaseName}-${versionName}"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -59,6 +60,7 @@ dependencies {
 
     // View Model extensions
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0"
 
     testImplementation "junit:junit:4.13.1"
 

--- a/lazyviewmodels/src/main/java/dev/ajkueterman/lazyviewmodels/ComponentActivity.kt
+++ b/lazyviewmodels/src/main/java/dev/ajkueterman/lazyviewmodels/ComponentActivity.kt
@@ -2,9 +2,9 @@ package dev.ajkueterman.lazyviewmodels
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.MainThread
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.*
+import androidx.savedstate.SavedStateRegistryOwner
 
 /**
  * An extension for [ComponentActivity] that provides a [ViewModel] by calling [viewModelBuilder]
@@ -18,7 +18,7 @@ import androidx.lifecycle.ViewModelProvider
  * @return a [VM] class instantiated by [Lazy], scoped to the Activity
  */
 @MainThread
-inline fun <reified VM : ViewModel> ComponentActivity.viewModelBuilder(
+inline fun <reified VM : ViewModel> ComponentActivity.lazyViewModels(
     noinline viewModelInitializer: () -> VM
 ): Lazy<VM> =
     ViewModelLazy(
@@ -28,8 +28,42 @@ inline fun <reified VM : ViewModel> ComponentActivity.viewModelBuilder(
             return@ViewModelLazy object : ViewModelProvider.Factory {
                 override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                     @Suppress("UNCHECKED_CAST")// Casting T as ViewModel
-                    return viewModelInitializer.invoke() as T
+                    return viewModelInitializer() as T
                 }
+            }
+        }
+    )
+
+/**
+ * An extension for [ComponentActivity] that provides a [ViewModel] by calling
+ * [viewModelInitializer] with a lambda closure that provides a [SavedStateHandle] and returns your
+ * custom [VM] class [ViewModel]. Returns a lazily instantiated [ViewModel] of your provided type
+ * using an [AbstractSavedStateViewModelFactory].
+ *
+ * Like `by viewModels()`, this extension creates a [ViewModel] scoped to this [ComponentActivity].
+ *
+ * @param owner the [SavedStateRegistryOwner] used to provide the [SavedStateHandle], defaults
+ * to this [ComponentActivity]
+ * @param viewModelInitializer the lambda which returns your custom class [VM] of type [ViewModel]
+ *
+ * @return a [VM] class instantiated by [Lazy], scoped to the Activity
+ */
+@MainThread
+inline fun <reified VM : ViewModel> ComponentActivity.lazySavedStateViewModels(
+    owner: SavedStateRegistryOwner = this,
+    noinline viewModelInitializer: (SavedStateHandle) -> VM
+): Lazy<VM> =
+    ViewModelLazy(
+        viewModelClass = VM::class,
+        storeProducer = { viewModelStore },
+        factoryProducer = {
+            return@ViewModelLazy object : AbstractSavedStateViewModelFactory(owner, null) {
+                @Suppress("UNCHECKED_CAST")// Casting T as ViewModel
+                override fun <T : ViewModel?> create(
+                    key: String,
+                    modelClass: Class<T>,
+                    handle: SavedStateHandle
+                ): T = viewModelInitializer(handle) as T
             }
         }
     )

--- a/lazyviewmodels/src/main/java/dev/ajkueterman/lazyviewmodels/Fragment.kt
+++ b/lazyviewmodels/src/main/java/dev/ajkueterman/lazyviewmodels/Fragment.kt
@@ -1,10 +1,10 @@
 package dev.ajkueterman.lazyviewmodels
 
+import androidx.activity.ComponentActivity
 import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
-import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.*
+import androidx.savedstate.SavedStateRegistryOwner
 
 /**
  * An extension on [Fragment] that provides a [ViewModel] by calling [activityViewModelBuilder]
@@ -18,7 +18,7 @@ import androidx.lifecycle.ViewModelProvider
  * @return a [VM] class instantiated by [Lazy], scoped to the Activity
  */
 @MainThread
-inline fun <reified VM : ViewModel> Fragment.activityViewModelBuilder(
+inline fun <reified VM : ViewModel> Fragment.lazyActivityViewModels(
     noinline viewModelInitializer: () -> VM
 ): Lazy<VM> =
     ViewModelLazy(
@@ -28,8 +28,43 @@ inline fun <reified VM : ViewModel> Fragment.activityViewModelBuilder(
             object : ViewModelProvider.Factory {
                 override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                     @Suppress("UNCHECKED_CAST")// Casting T as ViewModel
-                    return viewModelInitializer.invoke() as T
+                    return viewModelInitializer() as T
                 }
+            }
+        }
+    )
+
+/**
+ * An extension for [Fragment] that provides a [ViewModel] by calling
+ * [viewModelInitializer] with a lambda closure that provides a [SavedStateHandle] and returns your
+ * custom [VM] class [ViewModel]. Returns a lazily instantiated [ViewModel] of your provided type
+ * using an [AbstractSavedStateViewModelFactory].
+ *
+ * Like `by activityViewModels()`, this extension creates a [ViewModel] scoped to the parent
+ * [ComponentActivity].
+ *
+ * @param owner the [SavedStateRegistryOwner] used to provide the [SavedStateHandle], defaults
+ * to this [Fragment]
+ * @param viewModelInitializer the lambda which returns your custom class [VM] of type [ViewModel]
+ *
+ * @return a [VM] class instantiated by [Lazy], scoped to the Activity
+ */
+@MainThread
+inline fun <reified VM : ViewModel> Fragment.lazySavedStateActivityViewModels(
+    owner: SavedStateRegistryOwner = this,
+    noinline viewModelInitializer: (SavedStateHandle) -> VM
+): Lazy<VM> =
+    ViewModelLazy(
+        viewModelClass = VM::class,
+        storeProducer = { requireActivity().viewModelStore },
+        factoryProducer = {
+            return@ViewModelLazy object : AbstractSavedStateViewModelFactory(owner, null) {
+                @Suppress("UNCHECKED_CAST")// Casting T as ViewModel
+                override fun <T : ViewModel?> create(
+                    key: String,
+                    modelClass: Class<T>,
+                    handle: SavedStateHandle
+                ): T = viewModelInitializer(handle) as T
             }
         }
     )


### PR DESCRIPTION
Provide a `SavedStateHandle` to View Model construction lambda by way of the `AbstractSavedStateViewModelFactory`.

https://developer.android.com/reference/androidx/lifecycle/AbstractSavedStateViewModelFactory